### PR TITLE
build: set `manualChunks` to split a file into multiple files

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -19,6 +19,17 @@ export default defineConfig({
     tsconfigPaths(),
     visualizer(),
   ],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          react: ['react', 'react-dom'],
+          onnx: ['onnxruntime-web'],
+          echarts: ['echarts'],
+        },
+      },
+    },
+  },
   server: {
     port: 3000,
   },


### PR DESCRIPTION
`manualChunks` to split a file into multiple files for loading time speed up.

### Before

### `npm run build`

<img width="751" alt="image" src="https://github.com/user-attachments/assets/e89d98c5-66be-49f7-a33f-e532c3b155a8">

### Lighthouse

<img width="914" alt="image" src="https://github.com/user-attachments/assets/8b2da5ad-cb31-40f5-9798-b4eca4ec4626">


### After

### `npm run build`

<img width="752" alt="image" src="https://github.com/user-attachments/assets/b0dc09b9-017e-4b8b-8c6a-e08411aa6622">

### Lighthouse

<img width="1073" alt="image" src="https://github.com/user-attachments/assets/82692979-05ce-4294-82e8-dacd05450c45">

